### PR TITLE
Fix for partialmethod missing from python 2.7

### DIFF
--- a/striplog/utils.py
+++ b/striplog/utils.py
@@ -3,6 +3,8 @@
 Helper functions for the striplog package.
 
 """
+from __future__ import division
+
 from string import Formatter
 from functools import partial
 import re
@@ -132,18 +134,80 @@ def dict_repr_html(dictionary):
     return html
 
 
-class partialmethod(partial):
+class partialmethod(object):
+    """Method descriptor with partial application of the given arguments
+    and keywords.
+
+    Supports wrapping existing descriptors and handles non-descriptor
+    callables as instance methods.
     """
-    Extends partial to work on class methods.
-    """
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        return partial(self.func,
-                       instance,
-                       *(self.args or ()),
-                       **(self.keywords or {})
-                       )
+
+    def __init__(self, func, *args, **keywords):
+        if not callable(func) and not hasattr(func, "__get__"):
+            raise TypeError("{!r} is not callable or a descriptor"
+                                 .format(func))
+
+        # func could be a descriptor like classmethod which isn't callable,
+        # so we can't inherit from partial (it verifies func is callable)
+        if isinstance(func, partialmethod):
+            # flattening is mandatory in order to place cls/self before all
+            # other arguments
+            # it's also more efficient since only one function will be called
+            self.func = func.func
+            self.args = func.args + args
+            self.keywords = func.keywords.copy()
+            self.keywords.update(keywords)
+        else:
+            self.func = func
+            self.args = args
+            self.keywords = keywords
+
+    def __repr__(self):
+        args = ", ".join(map(repr, self.args))
+        keywords = ", ".join("{}={!r}".format(k, v)
+                                 for k, v in self.keywords.items())
+        format_string = "{module}.{cls}({func}, {args}, {keywords})"
+        return format_string.format(module=self.__class__.__module__,
+                                    cls=self.__class__.__qualname__,
+                                    func=self.func,
+                                    args=args,
+                                    keywords=keywords)
+
+    def _make_unbound_method(self):
+        def _method(*args, **keywords):
+            call_keywords = self.keywords.copy()
+            call_keywords.update(keywords)
+            all_args = args
+            cls_or_self = all_args[0]
+            rest = all_args[1:]
+            call_args = (cls_or_self,) + self.args + tuple(rest)
+            return self.func(*call_args, **call_keywords)
+        _method.__isabstractmethod__ = self.__isabstractmethod__
+        _method._partialmethod = self
+        return _method
+
+    def __get__(self, obj, cls):
+        get = getattr(self.func, "__get__", None)
+        result = None
+        if get is not None:
+            new_func = get(obj, cls)
+            if new_func is not self.func:
+                # Assume __get__ returning something new indicates the
+                # creation of an appropriate callable
+                result = partial(new_func, *self.args, **self.keywords)
+                try:
+                    result.__self__ = new_func.__self__
+                except AttributeError:
+                    pass
+        if result is None:
+            # If the underlying descriptor didn't do anything, treat this
+            # like an instance method
+            result = self._make_unbound_method().__get__(obj, cls)
+        return result
+
+    @property
+    def __isabstractmethod__(self):
+        return getattr(self.func, "__isabstractmethod__", False)
 
 
 def null(x):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,24 +20,6 @@ def test_null():
     assert null(null) == null
 
 
-def test_partial():
-    """Pretty sure this test doesn't test what I need. See coverage report.
-    """
-    def f(a, b):
-        return a + b
-
-    def g(a, b):
-        return b
-
-    p = partialmethod(f, b=0)
-    q = partialmethod(g, b=None)
-
-    # Can't see how to use utils.py lines 59-61.
-    assert p(1)
-    assert getattr(q, 'keywords', None)
-    assert q(1) is None
-
-
 def test_colours():
     """Test colour conversions.
     """


### PR DESCRIPTION
Bascially copied the Python 3 implementation of partialmethod - ref #91 

Still a few outstanding bugs for supporting py 2.7 which I will work on later.