### PR TITLE
Macrostrat columns

### DIFF
--- a/striplog/striplog.py
+++ b/striplog/striplog.py
@@ -2676,6 +2676,7 @@ def from_macrostrat(lng, lat, buffer_size=0.2):
     Returns:
         Tuple of:
             strip (striplog.Striplog)
+            legend (striplog.Legend)
 
     Example:
     lng = -64.3573186
@@ -2720,4 +2721,4 @@ def from_macrostrat(lng, lat, buffer_size=0.2):
                         base=component['best_age_bottom'],
                         components=[component], )
                         )
-    return Striplog(intervals)
+    return Striplog(intervals), legend


### PR DESCRIPTION
…columns for a given location.

This adds a `from_macrostrat` method to `striplog.striplog`. It expects a lng lat point, and will then use the MacroStrat API to get nearby geological units and construct a column based on the ages of the rocks within a buffer zone of the point (by default 0.2 degrees, but easily changed through a parameter). The column is returned as a `striplog.Striplog`.

While in `striplog.py`, this is not part of the `Striplog` class.

It is possible that I should just refactor this so that it does work as part of the class, but there are a handful of additional functions that handle part of the data munging. These could be pulled into the main function which could be moved into the class proper, if so desired. They have relatively little utility outside this specific application.

Example of usage:

    import striplog.striplog 
    import matplotlib.pyplot as plt

    lng = -64.3573186
    lat = 44.4454632
    buffer_size = 0.3
    the_strip = striplog.striplog.from_macrostrat(lng, lat, buffer_size)
    
    fig = plt.figure(figsize=(4,8))
    ax = fig.add_axes((0.2, 0.1, 0.3, 0.8))
    the_strip[0].plot(the_strip[1], aspect=5, match_only=['lith', 'age'], label='age', ax=ax)
    plt.show()

The plotting call should perhaps be overloaded to hide some complexity?

Resolves #109, but in a more roundabout way, since getting data at a point does not give a column, it returns values from all the data sources at the point.