### PR TITLE
Changing to "!=" with literal avoids SyntaxWarning

### DIFF
--- a/striplog/component.py
+++ b/striplog/component.py
@@ -226,7 +226,7 @@ class Component(object):
         if fmt == '':
             return default
 
-        keys = [k for k, v in self.__dict__.items() if v is not '']
+        keys = [k for k, v in self.__dict__.items() if v != '']
 
         f = fmt or '{' + '}, {'.join(keys) + '}'
 


### PR DESCRIPTION
Previously the following warning was raised when importing striplog:
`component.py:229: SyntaxWarning: "is not" with a literal.
Did you mean "!="?`

This change simply follows the suggested fix to avoid that warning.