### PR TITLE
Fix #135

### DIFF
--- a/striplog/striplog.py
+++ b/striplog/striplog.py
@@ -25,6 +25,7 @@ from .component import Component
 from .legend import Legend
 from .canstrat import parse_canstrat
 from .markov import Markov_chain
+from .lexicon import Lexicon
 from . import utils
 from . import templates
 
@@ -503,6 +504,12 @@ class Striplog(object):
         Returns:
             list.
         """
+        if not lexicon:
+            lexicon = Lexicon.default()
+            with warnings.catch_warnings():
+                warnings.simplefilter("module")
+                w = 'No lexicon provided, using the default.'
+                warnings.warn(w)
 
         include = include or {}
         exclude = exclude or {}
@@ -568,11 +575,18 @@ class Striplog(object):
                         if v is not None:
                             d[k] = v  # It's data
                 comp = [Component(c)] if c else None
-                this = Interval(**{'top': top,
-                                   'base': base,
-                                   'description': descr,
-                                   'data': d,
-                                   'components': comp})
+                if comp:
+                    this = Interval(**{'top': top,
+                                    'base': base,
+                                    'description': descr,
+                                    'data': d,
+                                    'components': comp})
+                elif not comp:
+                    this = Interval(**{'top': top,
+                                    'base': base,
+                                    'data': d,
+                                    'description': descr,
+                                    'lexicon': lexicon})
             else:
                 this = Interval(**{'top': top,
                                    'base': base,

--- a/tests/test_striplog.py
+++ b/tests/test_striplog.py
@@ -96,6 +96,11 @@ top_dict = {'Ardmore': 2510.03,
             'Niobrara': 2530.75
            }
 
+data_dict = {'top': [70.273, 70.744],
+             'facies': [3, 0],
+             'description': ['brown shale with interbedded sandstone pebbles', 'cyrstalline dolomite'],
+            }
+
 
 def test_error():
     """Test the generic error.
@@ -172,6 +177,14 @@ def test_from_dict():
     striplog = Striplog.from_dict(top_dict)
     assert len(striplog) == 7
     assert striplog.thinnest().summary() == '0.00 m of Cody'
+
+
+def test_descriptions_and_data():
+    """Test that descriptions are parsed into Components when
+    miscellaneous data is present.
+    """
+    strip = Striplog._build_list_of_Intervals(data_dict)
+    assert len(strip[0].components[0]) == 2
 
 
 def test_from_image():


### PR DESCRIPTION
Fixes #135
The Striplog constructor will now create Components if there is misc data given to it. If there are not components, then the `description` and either the provided `Lexicon` or the default one will be passed to the `Interval` constructor.

There is a new test for this case as well.