### PR TITLE
Update interval.py

### DIFF
--- a/striplog/interval.py
+++ b/striplog/interval.py
@@ -243,7 +243,7 @@ class Interval(object):
         Returns:
             str: Either 'point' or 'interval'.
         """
-        if self.thickness > 0:
+        if self.thickness == 0:
             return 'point'
         return 'interval'
 


### PR DESCRIPTION
Fix error in definition of `kind` of `Interval`. It should be a `point` if top = base (thickness = 0) and an `interval` if otherwise. Currently it returns `point` if top != base.