### PR TITLE
Fix potential bug in equality tests of `Position`s if `middle` is not explicitly defined.

### DIFF
--- a/striplog/position.py
+++ b/striplog/position.py
@@ -91,11 +91,11 @@ class Position(object):
         the total_ordering function to provide the others.
         """
         if isinstance(other, self.__class__):
-            return self.middle == other.middle
+            return self.z == other.z
 
     def __lt__(self, other):
         if isinstance(other, self.__class__):
-            return self.middle < other.middle
+            return self.z < other.z
 
     def _repr_html_(self):
         """


### PR DESCRIPTION
Changed `Position` to use the `z` attribute to test for equality and such. Previously `middle` was used, which could be a problem if it was not actually defined. Since `z` guarantees a `middle` exists, we should use it for these checks instead.