### PR TITLE
[BUG] np.int deprecated with np 1.20

### DIFF
--- a/striplog/striplog.py
+++ b/striplog/striplog.py
@@ -1289,7 +1289,7 @@ class Striplog:
         if (field is not None) or (legend_field is not None):
             result = np.zeros_like(basis, dtype=dtype)
         else:
-            result = np.zeros_like(basis, dtype=np.int)
+            result = np.zeros_like(basis, dtype=int)
 
         if np.isnan(undefined):
             try:


### PR DESCRIPTION
Hello there, 
coding a bit in subsurface, I got an error in the tests that `np.int` is deprecated in newer numpy versions:
``` 
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
Following the recommendation, I simply changed the single occurence in striplog to `int`

Best
Jan