### PR TITLE
Update striplog.py

### DIFF
--- a/striplog/striplog.py
+++ b/striplog/striplog.py
@@ -1764,7 +1764,11 @@ class Striplog:
         """
         for i, iv in enumerate(self):
             if iv.spans(d):
-                return i if index else iv
+                if iv.base.lower==d:
+                    pass
+                else:    
+                    return i if index else iv
+
         return None
 
     def depth(self, d):


### PR DESCRIPTION
PER Issue 159 - https://github.com/agilescientific/striplog/issues/159

Change to function read_at for values that define both the base of one interval and the top of the next